### PR TITLE
Updated droolsjbpm-parent dependency version to 6.0.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.drools</groupId>
         <artifactId>droolsjbpm-parent</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>6.0.0.Beta1</version>
         <!-- relativePath causes out-of-date problems on hudson slaves -->
         <!--<relativePath>../droolsjbpm-build-bootstrap/pom.xml</relativePath>-->
     </parent>


### PR DESCRIPTION
When I tried to run the demo (./buildandrun_h2.sh), it failed because the droolsjbpm-parent 6.0.0-SNAPSHOT dependency could not be found. 

Updating that to the latest version in the jboss repository (repository.jboss.org) fixed the problem. 
