### PR TITLE
Upgrade to jdom:1.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom</artifactId>
-            <version>1.1.2</version>
+            <version>1.1.3</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
jdom:1.1.3 intorduce dependency on jaxen:1.1.3 optional which avoids possible issue with compilation.
jdom:1.1.2 has dependency on maven-findbugs plugin due to jaxen dependency, which intorduced problems witt resolving
dependecies of maven-findbugs plugin
