### PR TITLE
DB Driver Class name is not selected when editing Teiid custom datasource

### DIFF
--- a/modules/dashboard-ui/dashboard-ui-panels/src/main/java/org/jboss/dashboard/ui/panel/dataSourceManagement/DataSourceManagementFormFormatter.java
+++ b/modules/dashboard-ui/dashboard-ui-panels/src/main/java/org/jboss/dashboard/ui/panel/dataSourceManagement/DataSourceManagementFormFormatter.java
@@ -84,6 +84,7 @@ public class DataSourceManagementFormFormatter extends Formatter {
                     setAttribute("selectedOracle", getDataSourceManagementHandler().getDriverClass().equals("oracle.jdbc.driver.OracleDriver") ? "selected" : "");
                     setAttribute("selectedSQLServer", getDataSourceManagementHandler().getDriverClass().equals("com.microsoft.sqlserver.jdbc.SQLServerDriver") ? "selected" : "");
                     setAttribute("selectedH2", getDataSourceManagementHandler().getDriverClass().equals("org.h2.Driver") ? "selected" : "");
+                    setAttribute("selectedTeiid", getDataSourceManagementHandler().getDriverClass().equals("org.teiid.jdbc.TeiidDriver") ? "selected" : "");
                 }
                 setAttribute("DriverClassName", driverClass != null ? StringEscapeUtils.escapeHtml(driverClass) : "");
 


### PR DESCRIPTION
BZ 1009872 - DB Driver Class name is not selected when editing Teiid custom datasource
