### PR TITLE
Add {value|raw} option 

### DIFF
--- a/modules/dashboard-displayers/dashboard-displayer-core/src/main/java/org/jboss/dashboard/displayer/table/TableColumn.java
+++ b/modules/dashboard-displayers/dashboard-displayer-core/src/main/java/org/jboss/dashboard/displayer/table/TableColumn.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 public class TableColumn {
 
     public static final String DEFAULT_HTMLVALUE = "{value}";
+    public static final String DEFAULT_HTMLVALUE_RAW = "{value|raw}";
 
     protected String propertyId;
     protected Table table;

--- a/modules/dashboard-ui/dashboard-ui-core/src/main/java/org/jboss/dashboard/ui/components/table/TableFormatter.java
+++ b/modules/dashboard-ui/dashboard-ui-core/src/main/java/org/jboss/dashboard/ui/components/table/TableFormatter.java
@@ -198,7 +198,12 @@ public class TableFormatter extends Formatter {
     protected String formatHtmlCellValue(Table table, TableColumn tableColumn, int row, int column) {
         if (StringUtils.isBlank(tableColumn.getHtmlValue())) return "";
         String result = tableColumn.getHtmlValue();
-        return StringUtils.replace(result, TableColumn.DEFAULT_HTMLVALUE, formatCellValue(table,row,column));
+        result = StringUtils.replace(result, TableColumn.DEFAULT_HTMLVALUE, formatCellValue(table,row,column)); // Replace {value} with html escaped value
+        String rawValue = null;
+        if (table.getValueAt(row, column) != null) {
+          rawValue = table.getValueAt(row, column).toString();
+        }
+        return StringUtils.replace(result, TableColumn.DEFAULT_HTMLVALUE_RAW, rawValue); // Replace {value|raw} with raw value
     }
 
     protected String getSortIcon(TableColumn column, int columnIndex) {

--- a/modules/dashboard-ui/dashboard-ui-core/src/main/java/org/jboss/dashboard/ui/components/table/TableHandler.java
+++ b/modules/dashboard-ui/dashboard-ui-core/src/main/java/org/jboss/dashboard/ui/components/table/TableHandler.java
@@ -234,7 +234,13 @@ public class TableHandler extends UIBeanHandler {
             String headerHTML = request.getRequestObject().getParameter("columnheaderhtmlstyle");
             String cellHTML = request.getRequestObject().getParameter("columncellhtmlstyle");
             String htmlValue = request.getRequestObject().getParameter("htmlvalue");
-            if (htmlValue == null || htmlValue.indexOf(TableColumn.DEFAULT_HTMLVALUE) == -1) htmlValue = TableColumn.DEFAULT_HTMLVALUE;
+            
+            boolean columnContainsValue = htmlValue.indexOf(TableColumn.DEFAULT_HTMLVALUE)     != -1;
+            columnContainsValue        |= htmlValue.indexOf(TableColumn.DEFAULT_HTMLVALUE_RAW) != -1;
+            if (htmlValue == null || !columnContainsValue) {
+              htmlValue = TableColumn.DEFAULT_HTMLVALUE;
+            }
+            
             boolean selectable = Boolean.valueOf(request.getRequestObject().getParameter("columnselectable")).booleanValue();
             boolean sortable = Boolean.valueOf(request.getRequestObject().getParameter("columnsortable")).booleanValue();
             Locale locale = LocaleManager.currentLocale();


### PR DESCRIPTION
Add {value|raw} option as a way to print the value of the field without adding html format. This adds the option to immediately render html tags from the database.

Usage: In a table, use {value|raw} instead of {value}. Now tags in the result will be rendered immediately. 

Handy to use if you want URL's which link using an ID, while the link should show the name of the entity.
