### PR TITLE
Minor improvements to batch script

### DIFF
--- a/builder/src/main/standalone-demo/scripts/start-demo.bat
+++ b/builder/src/main/standalone-demo/scripts/start-demo.bat
@@ -1,3 +1,4 @@
+@echo off
 echo.*****************************************************************************
 echo.*
 echo.* Starting the Dashboard Builder demo
@@ -7,4 +8,4 @@ echo.*
 echo.*
 echo.*****************************************************************************
 
-%JAVA_HOME%\bin\java %JAVA_OPTIONS% -jar jetty-runner.jar dashbuilder-demo.war
+"%JAVA_HOME%\bin\java" %JAVA_OPTIONS% -jar jetty-runner.jar dashbuilder-demo.war


### PR DESCRIPTION
JAVA_HOME usually points to something like `"C:\Program Files\..."`. Notice the whitespace. This breaks when the whole path isn't put in double quotes.

Also, `@echo off` makes everything a bit more friendly :)