### PR TITLE
Fix ARQ tests failing on Jenkins

### DIFF
--- a/modules/dashboard-commons/src/test/java/org/jboss/dashboard/test/MavenProjectHelper.java
+++ b/modules/dashboard-commons/src/test/java/org/jboss/dashboard/test/MavenProjectHelper.java
@@ -32,7 +32,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 public class MavenProjectHelper {
 
     public static final String JAVA_FOLDER = "java";
-    public static final String ROOT_DIR = "dashboard-builder";
 
     public static File getModuleDir(String moduleName) {
         File rootDir = MavenProjectHelper.getRootDir();
@@ -46,8 +45,10 @@ public class MavenProjectHelper {
 
     public static File getRootDir() {
         File rootDir = new File(System.getProperty("user.dir"));
-        while (rootDir != null && !ROOT_DIR.equals(rootDir.getName())) {
+        File parentPom = new File(rootDir.getParent(), "pom.xml");
+        while (parentPom.exists()) {
             rootDir = rootDir.getParentFile();
+            parentPom = new File(rootDir.getParent(), "pom.xml");
         }
         return rootDir;
     }


### PR DESCRIPTION
 * the tests are basically failing when the top-level
   dir is not called "dashboard-builder", but for
   example "dashboard-builder-6.3.x"

Please cherry-pick the changes also into 6.3.x and 6.2.x.