### PR TITLE
tests: fix the way module dirs are looked up

### DIFF
--- a/modules/dashboard-commons/src/test/java/org/jboss/dashboard/test/MavenProjectHelper.java
+++ b/modules/dashboard-commons/src/test/java/org/jboss/dashboard/test/MavenProjectHelper.java
@@ -37,10 +37,11 @@ public class MavenProjectHelper {
         File rootDir = MavenProjectHelper.getRootDir();
         if (rootDir == null) throw new NullPointerException("Root directory not found");
 
-        List<File> javaFolders = getFolders(rootDir, FileFilterUtils.nameFileFilter(moduleName));
-        if (!javaFolders.isEmpty()) return javaFolders.get(0);
-
-        throw new RuntimeException("Module " + moduleName + " dir not found. Root=" + rootDir.getPath());
+        File moduleDir = new File(rootDir, moduleName);
+        if (!moduleDir.isDirectory()) {
+            throw new RuntimeException("Module " + moduleName + " dir not found. Root=" + rootDir.getPath());
+        }
+        return moduleDir;
     }
 
     public static File getRootDir() {

--- a/modules/dashboard-samples/src/test/java/org/jboss/dashboard/showcase/ShowcaseKPITestsGenerator.java
+++ b/modules/dashboard-samples/src/test/java/org/jboss/dashboard/showcase/ShowcaseKPITestsGenerator.java
@@ -40,7 +40,7 @@ public class ShowcaseKPITestsGenerator {
         CDIBeanLocator.beanManager = container.getBeanManager();
         CodeBlockTrace.RUNTIME_CONTRAINTS_ENABLED = false;
 
-        File rootDir = MavenProjectHelper.getModuleDir("dashboard-samples");
+        File rootDir = MavenProjectHelper.getModuleDir("modules/dashboard-samples");
         File webAppDir = new File(rootDir, "src/main/webapp");
         Application.lookup().setBaseAppDirectory(webAppDir.getAbsolutePath());
 

--- a/modules/dashboard-samples/src/test/java/org/jboss/dashboard/showcase/ShowcaseKpisTest.java
+++ b/modules/dashboard-samples/src/test/java/org/jboss/dashboard/showcase/ShowcaseKpisTest.java
@@ -73,7 +73,7 @@ public class ShowcaseKpisTest {
         CDIBeanLocator.beanManager = beanManager;
         CodeBlockTrace.RUNTIME_CONTRAINTS_ENABLED = false;
 
-        rootDir = MavenProjectHelper.getModuleDir("dashboard-samples");
+        rootDir = MavenProjectHelper.getModuleDir("modules/dashboard-samples");
         webAppDir = new File(rootDir, "src/main/webapp");
         Application.lookup().setBaseAppDirectory(webAppDir.getAbsolutePath());
 


### PR DESCRIPTION
 * the previous approach was searching dirs as well,
   this is very error prone in case the root directory
   contains some unexcted content (like .repository for
   Jenkins builds). This new way requires users to
   specify the full path to the module, but on the
   other hand is much less prone to errors


@dgutierr please take a look. This should fix the test failures in the pullrequests job (we will see soon enough once the build for this PR finishes)