### PR TITLE
Fix Showcase KPI test

### DIFF
--- a/modules/dashboard-providers/dashboard-provider-core/src/main/java/org/jboss/dashboard/domain/label/LabelDomain.java
+++ b/modules/dashboard-providers/dashboard-provider-core/src/main/java/org/jboss/dashboard/domain/label/LabelDomain.java
@@ -172,7 +172,7 @@ public class LabelDomain extends AbstractDomain {
 
         // Include the aggregated interval only if visible.
         if (!isIntervalHidden(compositeInterval)) {
-            Set<Interval> otherIntervals = new HashSet<Interval>();
+            Set<Interval> otherIntervals = new TreeSet<Interval>();
             for (int i = maxNumberOfIntervals; i < intervals.size(); i++) otherIntervals.add(intervals.get(i));
             compositeInterval.setIntervals(otherIntervals);
             results.add(compositeInterval);

--- a/modules/dashboard-samples/src/test/java/org/jboss/dashboard/showcase/ShowcaseKpisTest.java
+++ b/modules/dashboard-samples/src/test/java/org/jboss/dashboard/showcase/ShowcaseKpisTest.java
@@ -507,7 +507,7 @@ public class ShowcaseKpisTest {
                     {"Saudi Arabia","83"},
                     {"Russia","67"},
                     {"Poland","88"},
-                    {"Australia, China, Netherlands, Canada, Mexico, Japan, Germany, Italy, France, Norway, India, Belgium, Indonesia, Brazil","1,051"}}, 0);
+                    {"Australia, Belgium, Brazil, Canada, China, France, Germany, India, Indonesia, Italy, Japan, Mexico, Netherlands, Norway","1,051"}}, 0);
         }
     }
 


### PR DESCRIPTION
The results obtained from iterating a HashSet implementation varies from java 1.7 to 1.8. 

The fix consists of using a TreeSet instead.