### PR TITLE
RHBPMS-4430: Restore the Chinese language

### DIFF
--- a/modules/dashboard-commons/src/main/java/org/jboss/dashboard/LocaleManager.java
+++ b/modules/dashboard-commons/src/main/java/org/jboss/dashboard/LocaleManager.java
@@ -42,7 +42,7 @@ public class LocaleManager {
     /**
      * The list of locales supported.
      */
-    @Inject @Config("en,es,de,fr,pt,ja")
+    @Inject @Config("en,es,de,fr,pt,ja,zh")
     protected String[] installedLocaleIds;
 
     /**

--- a/modules/dashboard-commons/src/test/java/org/jboss/dashboard/i18n/L10nTest.java
+++ b/modules/dashboard-commons/src/test/java/org/jboss/dashboard/i18n/L10nTest.java
@@ -96,6 +96,6 @@ public class L10nTest {
     @Test
     public void testSupportedLanguages() {
         String[] langIds = localeManager.getPlatformAvailableLangs();
-        assertThat(langIds).isEqualTo(new String[] {"en","es","de","fr","pt","ja"});
+        assertThat(langIds).isEqualTo(new String[] {"en","es","de","fr","pt","ja","zh"});
     }
 }


### PR DESCRIPTION
Restore the Traditional Chinese language as it was removed by error in a previous commit. Notice,  Dashbuilder only supports Traditional Chinese as there is no way to provide different versions for the same language.